### PR TITLE
fix: allow more recent `diffusers` versions

### DIFF
--- a/DeepCache/sd/unet_2d_blocks.py
+++ b/DeepCache/sd/unet_2d_blocks.py
@@ -20,7 +20,11 @@ from torch import nn
 
 from diffusers.utils import is_torch_version, logging
 from diffusers.models.activations import get_activation
-from diffusers.models.attention import AdaGroupNorm
+import diffusers
+if diffusers.__version__ >= '0.22.0':
+    from diffusers.models.normalization import AdaGroupNorm
+else:
+    from diffusers.models.attention import AdaGroupNorm
 from diffusers.models.attention_processor import Attention, AttnAddedKVProcessor, AttnAddedKVProcessor2_0
 from diffusers.models.dual_transformer_2d import DualTransformer2DModel
 from diffusers.models.resnet import Downsample2D, FirDownsample2D, FirUpsample2D, KDownsample2D, KUpsample2D, ResnetBlock2D, Upsample2D

--- a/DeepCache/sdxl/unet_2d_blocks.py
+++ b/DeepCache/sdxl/unet_2d_blocks.py
@@ -20,7 +20,11 @@ from torch import nn
 
 from diffusers.utils import is_torch_version, logging
 from diffusers.models.activations import get_activation
-from diffusers.models.attention import AdaGroupNorm
+import diffusers
+if diffusers.__version__ >= '0.22.0':
+    from diffusers.models.normalization import AdaGroupNorm
+else:
+    from diffusers.models.attention import AdaGroupNorm
 from diffusers.models.attention_processor import Attention, AttnAddedKVProcessor, AttnAddedKVProcessor2_0
 from diffusers.models.dual_transformer_2d import DualTransformer2DModel
 from diffusers.models.resnet import Downsample2D, FirDownsample2D, FirUpsample2D, KDownsample2D, KUpsample2D, ResnetBlock2D, Upsample2D


### PR DESCRIPTION
I dont know why you only want a certain version of diffusers, but this little check lets you use later versions of diffusers.